### PR TITLE
fix: constrain NvimTree height and restore panel widths on open/close (closes #4, closes #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,42 @@ make check
 - ✅ Autocmd creation and handling
 - ✅ Error conditions and edge cases
 
+## 🌲 NvimTree Integration
+
+Nvibe automatically handles NvimTree layout conflicts so your panels stay intact when you toggle the file explorer.
+
+### What's fixed (v0.1.2+)
+- **Issue #4** — Opening NvimTree no longer rebalances and breaks the nvibe layout
+- **Issue #5** — NvimTree is constrained to the editor-row height; it won't span the full Neovim height over your terminal panes
+
+### Recommended NvimTree config (in your NvChad `plugins.lua`)
+
+For best results with nvibe's layout, configure NvimTree to not auto-resize on open:
+
+```lua
+{
+  "nvim-tree/nvim-tree.lua",
+  opts = {
+    view = {
+      width = 30,
+      side = "left",
+      -- Prevent NvimTree from resizing other windows when it opens
+      preserve_window_proportions = true,
+    },
+    -- Keep focus in the editor after NvimTree opens
+    hijack_cursor = false,
+    update_focused_file = {
+      enable = true,
+      update_root = false, -- don't re-root when switching files
+    },
+  },
+}
+```
+
+> **Note:** `preserve_window_proportions = true` is the key setting. Without it, NvimTree triggers a full window equalization that resets the nvibe panel widths.
+
+---
+
 ## 🤝 Contributing
 
 We love contributions! Here's how you can help:


### PR DESCRIPTION
## Problem

Two related NvimTree layout bugs when nvibe is active:

- **#4** — `<leader>e` triggers Neovim's window equalization, blowing up nvibe's carefully sized left/bottom panels
- **#5** — NvimTree spans the full Neovim height, covering the bottom terminal panes instead of staying in the editor row

## Solution

### Code changes (`lua/nvibe/init.lua`)
1. **Track editor window + height** after layout is built (deferred 300ms so all panels are settled)
2. **`M.rebalance_panels()`** — new function that finds left-column terminal windows and restores their width
3. **`NvibeNvimTree` autocmd group** (registered in `M.setup()`):
   - `FileType=NvimTree` → set height to cached editor height, then call `rebalance_panels()`
   - `BufWinLeave/BufUnload` for NvimTree buftype → call `rebalance_panels()`

### Docs (`README.md`)
Added **NvimTree Integration** section with:
- What's fixed in this release
- Recommended NvimTree config (`preserve_window_proportions = true`) — the key setting that prevents the equalization trigger
- Explanation of why it matters

## Testing
1. Open nvim (nvibe auto-starts)
2. Press `<leader>e` — NvimTree should open constrained to editor height, panels should stay sized
3. Close NvimTree — panels should stay intact

Closes #4, closes #5

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two NvimTree layout bugs by introducing a height constraint mechanism and panel rebalancing system. The solution caches the editor window height after layout creation and applies it to NvimTree when opened, while also restoring terminal panel widths via autocmd hooks.

- Caches editor window ID and height after initial layout creation (300ms deferred)
- New `rebalance_panels()` function restores left-column terminal widths by detecting windows at column 0 with buftype "terminal"
- Autocmd group handles NvimTree FileType event (constrains height + rebalances) and close events (rebalances only)
- Documentation added with recommended NvimTree config highlighting `preserve_window_proportions = true`

**Minor issue found**: The `BufWinLeave`/`BufUnload` autocmd should use the event buffer (`ev.buf`) instead of `vim.api.nvim_get_current_buf()` for more reliable filetype checking.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor fix recommended
- The implementation is solid and addresses the stated issues effectively. The autocmd logic works but could be more robust by using the event buffer parameter. The 300ms and 50ms defer timings are reasonable for layout stabilization. Documentation is thorough and helpful.
- lua/nvibe/init.lua line 346 should be updated to use event buffer

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lua/nvibe/init.lua | Adds NvimTree integration with height constraint and panel rebalancing. One issue: autocmd callback should use event buffer instead of current buffer |
| README.md | Adds comprehensive NvimTree integration documentation with setup instructions and explanation |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant VimEnter
    participant NvimTree
    participant Nvibe
    
    User->>VimEnter: Launch Neovim
    VimEnter->>Nvibe: create_terminal_split()
    Note over Nvibe: Build layout with terminals
    VimEnter->>Nvibe: defer_fn(300ms)
    Note over Nvibe: Cache editor window + height
    
    User->>NvimTree: Open (<leader>e)
    NvimTree->>Nvibe: FileType autocmd fires
    Nvibe->>Nvibe: defer_fn(50ms)
    Nvibe->>NvimTree: Set height to cached value
    Nvibe->>Nvibe: rebalance_panels()
    Note over Nvibe: Restore left terminal widths
    
    User->>NvimTree: Close NvimTree
    NvimTree->>Nvibe: BufWinLeave/BufUnload fires
    Nvibe->>Nvibe: defer_fn(50ms)
    Nvibe->>Nvibe: rebalance_panels()
    Note over Nvibe: Restore left terminal widths
```

<sub>Last reviewed commit: 6356838</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->