### PR TITLE
ci: add build gate to keep production build green (closes #13)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build Gate
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.1.38"
+
+      - name: Install
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build


### PR DESCRIPTION
## Summary
- adds GitHub Actions build gate for PRs and main
- runs `bun install --frozen-lockfile` and `bun run build`

## Why
Addresses P0 release blocker #13 by enforcing production build health in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated build verification for pull requests and deployments to ensure code quality and consistency across changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds GitHub Actions workflow for CI, but uses completely wrong tooling for this Lua plugin.

**Critical issues:**
- Uses Bun/JavaScript tooling for a Lua Neovim plugin
- `bun install --frozen-lockfile` will fail (no `package.json` exists)
- `bun run build` will fail (no build script exists)
- Project actually uses `make check` to run luacheck linter and busted tests

**This workflow will fail 100% of the time and does not address the stated goal of keeping the production build green.**

<h3>Confidence Score: 0/5</h3>

- This PR introduces a completely non-functional CI workflow that will fail on every run
- Workflow uses wrong programming language tooling (Bun for a Lua project), references non-existent files and scripts, and cannot possibly work
- `.github/workflows/build.yml` requires complete rewrite using Lua/Luarocks tooling and `make check`

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/build.yml | Workflow uses wrong tooling (Bun) for Lua plugin - will fail on all runs, should use Lua/Luarocks with `make check` |

</details>



<sub>Last reviewed commit: 26cac77</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->